### PR TITLE
Add ability to set custom size definition to TabmanBar

### DIFF
--- a/Docs/ADVANCED_CUSTOMISATION.md
+++ b/Docs/ADVANCED_CUSTOMISATION.md
@@ -46,8 +46,10 @@ override func update(forPosition position: CGFloat,
 	// update your bar for a positional update here              
 }
 
-override func update(forAppearance appearance: TabmanBar.AppearanceConfig) {
-	super.update(forAppearance: appearance)
+override func update(forAppearance appearance: Appearance, 
+                     defaultAppearance: Appearance) {
+	super.update(forAppearance: appearance,
+	             defaultAppearance: defaultAppearance)
         
 	// update the bar appearance here
 }

--- a/Example/Tabman-Example.xcodeproj/project.pbxproj
+++ b/Example/Tabman-Example.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		D6020AC41E602BB500C2B7BA /* PureLayout.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D62AC18D1E5B03B50020B8AE /* PureLayout.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D6020AC71E602BBB00C2B7BA /* Pageboy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D62AC1501E5AF5440020B8AE /* Pageboy.framework */; };
 		D6020AC81E602BBB00C2B7BA /* Pageboy.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D62AC1501E5AF5440020B8AE /* Pageboy.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D616D06E1E72E2C600C7AA32 /* PresetAppeareanceConfigs.swift in Sources */ = {isa = PBXBuildFile; fileRef = D616D06D1E72E2C600C7AA32 /* PresetAppeareanceConfigs.swift */; };
+		D616D06E1E72E2C600C7AA32 /* PresetAppearanceConfigs.swift in Sources */ = {isa = PBXBuildFile; fileRef = D616D06D1E72E2C600C7AA32 /* PresetAppearanceConfigs.swift */; };
 		D61E50BC1E64452D00AC8C75 /* CircularButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61E50BB1E64452D00AC8C75 /* CircularButton.swift */; };
 		D61E50C81E644A2200AC8C75 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61E50C71E644A2200AC8C75 /* SettingsViewController.swift */; };
 		D61E50CA1E644A7500AC8C75 /* SettingsNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61E50C91E644A7500AC8C75 /* SettingsNavigationController.swift */; };
@@ -171,7 +171,7 @@
 
 /* Begin PBXFileReference section */
 		D601367C1E6990650013CD42 /* CustomTabmanBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomTabmanBar.swift; sourceTree = "<group>"; };
-		D616D06D1E72E2C600C7AA32 /* PresetAppeareanceConfigs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresetAppeareanceConfigs.swift; sourceTree = "<group>"; };
+		D616D06D1E72E2C600C7AA32 /* PresetAppearanceConfigs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresetAppearanceConfigs.swift; sourceTree = "<group>"; };
 		D61E50BB1E64452D00AC8C75 /* CircularButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircularButton.swift; sourceTree = "<group>"; };
 		D61E50C71E644A2200AC8C75 /* SettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		D61E50C91E644A7500AC8C75 /* SettingsNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsNavigationController.swift; sourceTree = "<group>"; };
@@ -292,7 +292,7 @@
 		D62AC10E1E5736B20020B8AE /* Example Components */ = {
 			isa = PBXGroup;
 			children = (
-				D616D06D1E72E2C600C7AA32 /* PresetAppeareanceConfigs.swift */,
+				D616D06D1E72E2C600C7AA32 /* PresetAppearanceConfigs.swift */,
 				D62AC1071E5736A10020B8AE /* TabViewControllerExtras.swift */,
 				D61E50CF1E647F0000AC8C75 /* Settings */,
 				D62AC1051E5736A10020B8AE /* GradientView.swift */,
@@ -536,7 +536,7 @@
 				D61E50D31E6482EE00AC8C75 /* SettingsSection.swift in Sources */,
 				D62AC1091E5736A10020B8AE /* ChildViewController.swift in Sources */,
 				D629EBC11E65D2D900CDF88F /* SettingsPushTransitionController.swift in Sources */,
-				D616D06E1E72E2C600C7AA32 /* PresetAppeareanceConfigs.swift in Sources */,
+				D616D06E1E72E2C600C7AA32 /* PresetAppearanceConfigs.swift in Sources */,
 				D601367D1E6990650013CD42 /* CustomTabmanBar.swift in Sources */,
 				D62AC10D1E5736A10020B8AE /* TransparentNavigationBar.swift in Sources */,
 				D62AC10C1E5736A10020B8AE /* TabViewControllerExtras.swift in Sources */,

--- a/Example/Tabman-Example/CustomTabmanBar.swift
+++ b/Example/Tabman-Example/CustomTabmanBar.swift
@@ -53,8 +53,10 @@ class CustomTabmanBar: TabmanBar {
         // update your bar for a positional update here
     }
     
-    override func update(forAppearance appearance: TabmanBar.Appearance) {
-        super.update(forAppearance: appearance)
+    override func update(forAppearance appearance: Appearance,
+                         defaultAppearance: Appearance) {
+        super.update(forAppearance: appearance,
+                     defaultAppearance: defaultAppearance)
         
         // update the bar appearance here
     }

--- a/Example/Tabman-Example/PresetAppearanceConfigs.swift
+++ b/Example/Tabman-Example/PresetAppearanceConfigs.swift
@@ -1,5 +1,5 @@
 //
-//  PresetAppeareanceConfigs.swift
+//  PresetAppearanceConfigs.swift
 //  Tabman-Example
 //
 //  Created by Merrick Sapsford on 10/03/2017.
@@ -9,7 +9,7 @@
 import Foundation
 import Tabman
 
-class PresetAppeareanceConfigs: Any {
+class PresetAppearanceConfigs: Any {
     
     static func forStyle(_ style: TabmanBar.Style, currentAppearance: TabmanBar.Appearance?) -> TabmanBar.Appearance? {
         let appearance = currentAppearance ?? TabmanBar.Appearance.defaultAppearance

--- a/Example/Tabman-Example/SettingsEntries.swift
+++ b/Example/Tabman-Example/SettingsEntries.swift
@@ -35,7 +35,7 @@ extension SettingsViewController {
             { (value) in
                 let style = TabmanBar.Style.fromDescription(value as! String)
                 self.tabViewController?.bar.style = style
-                self.tabViewController?.bar.appearance = PresetAppeareanceConfigs.forStyle(style,
+                self.tabViewController?.bar.appearance = PresetAppearanceConfigs.forStyle(style,
                                                                                            currentAppearance: self.tabViewController?.bar.appearance)
         }))
         appearanceSection.add(item: SettingsItem(type: .options(values: ["Default",

--- a/Example/Tabman-Example/TabViewController.swift
+++ b/Example/Tabman-Example/TabViewController.swift
@@ -54,7 +54,7 @@ class TabViewController: TabmanViewController, PageboyViewControllerDataSource {
         
         self.dataSource = self
         
-        self.bar.appearance = PresetAppeareanceConfigs.forStyle(self.bar.style, currentAppearance: self.bar.appearance)
+        self.bar.appearance = PresetAppearanceConfigs.forStyle(self.bar.style, currentAppearance: self.bar.appearance)
         self.updateAppearance(pagePosition: self.currentPosition?.x ?? 0.0)
         self.updateStatusLabels()
         self.updateBarButtonStates(index: self.currentIndex ?? 0)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The `TabmanBarAppearance` object provides all the available properties for appea
 To set a custom appearance definition do this on a `TabmanViewController`:
 
 ```swift
-tabViewController.bar.appearance = TabmanBar.AppearanceConfig({ (appearance) in
+tabViewController.bar.appearance = TabmanBar.Appearance({ (appearance) in
 	// customise appearance here
 	appearance.text.color = UIColor.red
 	appearance.indicator.isProgressive = true

--- a/Sources/Tabman.xcodeproj/project.pbxproj
+++ b/Sources/Tabman.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		D66FEEC01E79688000E7E87A /* TabmanBar+Construction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66FEEBF1E79688000E7E87A /* TabmanBar+Construction.swift */; };
 		D66FEEC31E7971AF00E7E87A /* TabmanButtonBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66FEEC21E7971AF00E7E87A /* TabmanButtonBar.swift */; };
 		D66FEEDA1E7A912A00E7E87A /* TabmanStaticButtonBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66FEED91E7A912A00E7E87A /* TabmanStaticButtonBar.swift */; };
+		D66FEEDC1E7AA51000E7E87A /* ViewUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66FEEDB1E7AA51000E7E87A /* ViewUtils.swift */; };
 		D68FBA761E700E2400B96EC0 /* TabmanIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68FBA751E700E2400B96EC0 /* TabmanIndicatorTests.swift */; };
 		D68FBA781E700F1300B96EC0 /* TabmanTestIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68FBA771E700F1300B96EC0 /* TabmanTestIndicator.swift */; };
 		D68FBA7A1E70159400B96EC0 /* TabmanViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68FBA791E70159400B96EC0 /* TabmanViewControllerTests.swift */; };
@@ -107,6 +108,7 @@
 		D66FEEBF1E79688000E7E87A /* TabmanBar+Construction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TabmanBar+Construction.swift"; sourceTree = "<group>"; };
 		D66FEEC21E7971AF00E7E87A /* TabmanButtonBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabmanButtonBar.swift; sourceTree = "<group>"; };
 		D66FEED91E7A912A00E7E87A /* TabmanStaticButtonBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabmanStaticButtonBar.swift; sourceTree = "<group>"; };
+		D66FEEDB1E7AA51000E7E87A /* ViewUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewUtils.swift; sourceTree = "<group>"; };
 		D68FBA751E700E2400B96EC0 /* TabmanIndicatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabmanIndicatorTests.swift; sourceTree = "<group>"; };
 		D68FBA771E700F1300B96EC0 /* TabmanTestIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabmanTestIndicator.swift; sourceTree = "<group>"; };
 		D68FBA791E70159400B96EC0 /* TabmanViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabmanViewControllerTests.swift; sourceTree = "<group>"; };
@@ -313,6 +315,7 @@
 			children = (
 				D616D0B81E78065500C7AA32 /* PositionalUtils.swift */,
 				D616D0BC1E783E6400C7AA32 /* ImageUtils.swift */,
+				D66FEEDB1E7AA51000E7E87A /* ViewUtils.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -461,6 +464,7 @@
 				D601367B1E6989B50013CD42 /* TabmanBarConfig.swift in Sources */,
 				D616D0A31E77EFC600C7AA32 /* TabmanBarTransitionStore.swift in Sources */,
 				D62AC1231E5748D80020B8AE /* TabmanAutoLayout.swift in Sources */,
+				D66FEEDC1E7AA51000E7E87A /* ViewUtils.swift in Sources */,
 				D68FBA811E701D1A00B96EC0 /* TabmanCircularView.swift in Sources */,
 				D616D06C1E72C1FC00C7AA32 /* TabmanLineIndicator.swift in Sources */,
 				D616D0B91E78065500C7AA32 /* PositionalUtils.swift in Sources */,

--- a/Sources/Tabman/TabmanBar/Styles/Concrete/TabmanButtonBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/Concrete/TabmanButtonBar.swift
@@ -63,8 +63,10 @@ public class TabmanButtonBar: TabmanBar {
         self.edgeMarginConstraints.removeAll()
     }
     
-    public override func update(forAppearance appearance: TabmanBar.Appearance) {
-        super.update(forAppearance: appearance)
+    public override func update(forAppearance appearance: Appearance,
+                                defaultAppearance: Appearance) {
+        super.update(forAppearance: appearance,
+                     defaultAppearance: defaultAppearance)
         
         if let interItemSpacing = appearance.layout.interItemSpacing {
             self.interItemSpacing = interItemSpacing

--- a/Sources/Tabman/TabmanBar/Styles/Concrete/TabmanButtonBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/Concrete/TabmanButtonBar.swift
@@ -55,10 +55,6 @@ public class TabmanButtonBar: TabmanBar {
     
     // Public
     
-    override public var intrinsicContentSize: CGSize {
-        return CGSize(width: 0.0, height: Defaults.height)
-    }
-    
     /// The spacing between each bar item. (Default = 20.0)
     public var interItemSpacing: CGFloat = Appearance.defaultAppearance.layout.interItemSpacing ?? Defaults.horizontalSpacing
     

--- a/Sources/Tabman/TabmanBar/Styles/Concrete/TabmanButtonBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/Concrete/TabmanButtonBar.swift
@@ -29,7 +29,15 @@ public class TabmanButtonBar: TabmanBar {
     
     internal var buttons = [UIButton]()
     
-    internal var textFont: UIFont = Appearance.defaultAppearance.text.font!
+    internal var textFont: UIFont = Appearance.defaultAppearance.text.font! {
+        didSet {
+            guard textFont != oldValue else { return }
+            
+            self.updateButtons(update: { (button) in
+                button.titleLabel?.font = textFont
+            })
+        }
+    }
     internal var color: UIColor = Appearance.defaultAppearance.state.color!
     internal var selectedColor: UIColor = Appearance.defaultAppearance.state.selectedColor!
     
@@ -68,19 +76,20 @@ public class TabmanButtonBar: TabmanBar {
         super.update(forAppearance: appearance,
                      defaultAppearance: defaultAppearance)
         
-        if let interItemSpacing = appearance.layout.interItemSpacing {
-            self.interItemSpacing = interItemSpacing
-        }
+        let color = appearance.state.color
+        self.color = color ?? defaultAppearance.state.color!
         
-        if let textFont = appearance.text.font {
-            self.textFont = textFont
-            self.updateButtons(update: { (button) in
-                button.titleLabel?.font = textFont
-            })
-        }
+        let selectedColor = appearance.state.selectedColor
+        self.selectedColor = selectedColor ?? defaultAppearance.state.selectedColor!
         
-        if let indicatorWeight = appearance.indicator.lineWeight,
-            let lineIndicator = self.indicator as? TabmanLineIndicator {
+        let interItemSpacing = appearance.layout.interItemSpacing
+        self.interItemSpacing = interItemSpacing ?? defaultAppearance.layout.interItemSpacing!
+        
+        let textFont = appearance.text.font
+        self.textFont = textFont ?? defaultAppearance.text.font!
+        
+        let indicatorWeight = appearance.indicator.lineWeight ?? defaultAppearance.indicator.lineWeight!
+        if let lineIndicator = self.indicator as? TabmanLineIndicator {
             lineIndicator.weight = indicatorWeight
         }
     }

--- a/Sources/Tabman/TabmanBar/Styles/Concrete/TabmanButtonBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/Concrete/TabmanButtonBar.swift
@@ -18,12 +18,6 @@ public class TabmanButtonBar: TabmanBar {
     //
     
     private struct Defaults {
-        static let selectedColor: UIColor = .black
-        static let color: UIColor = UIColor.black.withAlphaComponent(0.5)
-        
-        static let horizontalSpacing: CGFloat = 20.0
-        
-        static let textFont: UIFont = UIFont.systemFont(ofSize: 16.0)
         
         static let itemHeight: CGFloat = 50.0
         static let itemImageSize: CGSize = CGSize(width: 25.0, height: 25.0)
@@ -35,9 +29,9 @@ public class TabmanButtonBar: TabmanBar {
     
     internal var buttons = [UIButton]()
     
-    internal var textFont: UIFont = Appearance.defaultAppearance.text.font ?? Defaults.textFont
-    internal var color: UIColor = Appearance.defaultAppearance.state.color ?? Defaults.color
-    internal var selectedColor: UIColor = Appearance.defaultAppearance.state.selectedColor ?? Defaults.selectedColor
+    internal var textFont: UIFont = Appearance.defaultAppearance.text.font!
+    internal var color: UIColor = Appearance.defaultAppearance.state.color!
+    internal var selectedColor: UIColor = Appearance.defaultAppearance.state.selectedColor!
     
     internal var horizontalMarginConstraints = [NSLayoutConstraint]()
     internal var edgeMarginConstraints = [NSLayoutConstraint]()
@@ -55,8 +49,8 @@ public class TabmanButtonBar: TabmanBar {
     
     // Public
     
-    /// The spacing between each bar item. (Default = 20.0)
-    public var interItemSpacing: CGFloat = Appearance.defaultAppearance.layout.interItemSpacing ?? Defaults.horizontalSpacing
+    /// The spacing between each bar item.
+    public var interItemSpacing: CGFloat = Appearance.defaultAppearance.layout.interItemSpacing!
     
     //
     // MARK: TabmanBar Lifecycle

--- a/Sources/Tabman/TabmanBar/Styles/Concrete/TabmanButtonBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/Concrete/TabmanButtonBar.swift
@@ -111,6 +111,9 @@ public class TabmanButtonBar: TabmanBar {
                 button.setImage(resizedImage.withRenderingMode(.alwaysTemplate), for: .normal)
             }
             
+            // appearance
+            button.titleLabel?.adjustsFontSizeToFitWidth = true
+            
             // layout
             NSLayoutConstraint.autoSetPriority(500, forConstraints: {
                 button.autoSetDimension(.height, toSize: Defaults.itemHeight)

--- a/Sources/Tabman/TabmanBar/Styles/Concrete/TabmanButtonBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/Concrete/TabmanButtonBar.swift
@@ -25,7 +25,7 @@ public class TabmanButtonBar: TabmanBar {
         
         static let textFont: UIFont = UIFont.systemFont(ofSize: 16.0)
         
-        static let height: CGFloat = 50.0
+        static let itemHeight: CGFloat = 50.0
         static let itemImageSize: CGSize = CGSize(width: 25.0, height: 25.0)
     }
     
@@ -112,8 +112,12 @@ public class TabmanButtonBar: TabmanBar {
             }
             
             // layout
+            NSLayoutConstraint.autoSetPriority(500, forConstraints: {
+                button.autoSetDimension(.height, toSize: Defaults.itemHeight)
+            })
             button.autoPinEdge(toSuperviewEdge: .top)
             button.autoPinEdge(toSuperviewEdge: .bottom)
+            
             if previousButton == nil { // pin to left
                 self.edgeMarginConstraints.append(button.autoPinEdge(toSuperviewEdge: .leading))
             } else {

--- a/Sources/Tabman/TabmanBar/Styles/TabmanBlockTabBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/TabmanBlockTabBar.swift
@@ -99,8 +99,10 @@ public class TabmanBlockTabBar: TabmanStaticButtonBar {
         self.maskContentView = maskContentView
     }
 
-    override public func update(forAppearance appearance: TabmanBar.Appearance) {
-        super.update(forAppearance: appearance)
+    override public func update(forAppearance appearance: Appearance,
+                                defaultAppearance: Appearance) {
+        super.update(forAppearance: appearance,
+                     defaultAppearance: defaultAppearance)
         
         if let color = appearance.state.color {
             self.updateButtonsInView(view: self.buttonContentView, update: { (button) in

--- a/Sources/Tabman/TabmanBar/Styles/TabmanBlockTabBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/TabmanBlockTabBar.swift
@@ -14,17 +14,6 @@ import Pageboy
 public class TabmanBlockTabBar: TabmanStaticButtonBar {
     
     //
-    // MARK: Constants
-    //
-    
-    private struct Defaults {
-        
-        static let selectedColor: UIColor = .black
-        static let color: UIColor = UIColor.black.withAlphaComponent(0.5)
-
-    }
-    
-    //
     // MARK: Properties
     //
     

--- a/Sources/Tabman/TabmanBar/Styles/TabmanBlockTabBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/TabmanBlockTabBar.swift
@@ -20,8 +20,6 @@ public class TabmanBlockTabBar: TabmanStaticButtonBar {
     private var buttonContentView: UIView?
     private var maskContentView: UIView?
     
-    // Public
-    
     public override var interItemSpacing: CGFloat {
         didSet {
             let insets = UIEdgeInsets(top: 0.0, left: interItemSpacing / 2, bottom: 0.0, right: interItemSpacing / 2)
@@ -33,6 +31,28 @@ public class TabmanBlockTabBar: TabmanStaticButtonBar {
                 button.titleEdgeInsets = insets
                 button.imageEdgeInsets = insets
             }
+        }
+    }
+    
+    override var color: UIColor {
+        didSet {
+            guard color != oldValue else { return }
+            
+            self.updateButtonsInView(view: self.buttonContentView, update: { (button) in
+                button.tintColor = color
+                button.setTitleColor(color, for: .normal)
+            })
+        }
+    }
+    
+    override var selectedColor: UIColor {
+        didSet {
+            guard selectedColor != oldValue else { return }
+            
+            self.updateButtonsInView(view: self.maskContentView, update: { (button) in
+                button.tintColor = selectedColor
+                button.setTitleColor(selectedColor, for: .normal)
+            })
         }
     }
     
@@ -97,25 +117,5 @@ public class TabmanBlockTabBar: TabmanStaticButtonBar {
         
         self.buttonContentView = buttonContentView
         self.maskContentView = maskContentView
-    }
-
-    override public func update(forAppearance appearance: Appearance,
-                                defaultAppearance: Appearance) {
-        super.update(forAppearance: appearance,
-                     defaultAppearance: defaultAppearance)
-        
-        if let color = appearance.state.color {
-            self.updateButtonsInView(view: self.buttonContentView, update: { (button) in
-                button.tintColor = color
-                button.setTitleColor(color, for: .normal)
-            })
-        }
-        
-        if let selectedColor = appearance.state.selectedColor {
-            self.updateButtonsInView(view: self.maskContentView, update: { (button) in
-                button.tintColor = selectedColor
-                button.setTitleColor(selectedColor, for: .normal)
-            })
-        }
     }
 }

--- a/Sources/Tabman/TabmanBar/Styles/TabmanScrollingButtonBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/TabmanScrollingButtonBar.swift
@@ -41,7 +41,12 @@ public class TabmanScrollingButtonBar: TabmanButtonBar {
     /// Whether scroll is enabled on the bar.
     public var isScrollEnabled: Bool {
         set(isScrollEnabled) {
+            guard isScrollEnabled != self.scrollView.isScrollEnabled else { return }
+
             self.scrollView.isScrollEnabled = isScrollEnabled
+            UIView.animate(withDuration: 0.3, animations: { // reset scroll position
+                self.transitionStore?.indicatorTransition(forBar: self)?.updateForCurrentPosition()
+            })
         }
         get {
             return self.scrollView.isScrollEnabled
@@ -53,6 +58,8 @@ public class TabmanScrollingButtonBar: TabmanButtonBar {
         didSet {
             self.updateConstraints(self.edgeMarginConstraints,
                                    withValue: edgeInset)
+            self.layoutIfNeeded()
+            self.updateForCurrentPosition()
         }
     }
     
@@ -60,6 +67,27 @@ public class TabmanScrollingButtonBar: TabmanButtonBar {
         didSet {
             self.updateConstraints(self.horizontalMarginConstraints,
                                    withValue: interItemSpacing)
+        }
+    }
+    
+    override var color: UIColor {
+        didSet {
+            guard color != oldValue else { return }
+            
+            self.updateButtons(withContext: .unselected, update: { button in
+                button.setTitleColor(color, for: .normal)
+                button.setTitleColor(color.withAlphaComponent(0.3), for: .highlighted)
+                button.tintColor = color
+            })
+        }
+    }
+    
+    override var selectedColor: UIColor {
+        didSet {
+            guard selectedColor != oldValue else { return }
+            
+            self.focussedButton?.setTitleColor(selectedColor, for: .normal)
+            self.focussedButton?.tintColor = selectedColor
         }
     }
     
@@ -133,42 +161,15 @@ public class TabmanScrollingButtonBar: TabmanButtonBar {
         super.update(forAppearance: appearance,
                      defaultAppearance: defaultAppearance)
         
-        if let color = appearance.state.color {
-            self.color = color
-            self.updateButtons(withContext: .unselected, update: { button in
-                button.setTitleColor(color, for: .normal)
-                button.setTitleColor(color.withAlphaComponent(0.3), for: .highlighted)
-                button.tintColor = color
-            })
-        }
+        let edgeInset = appearance.layout.edgeInset
+        self.edgeInset = edgeInset ?? defaultAppearance.layout.edgeInset!
         
-        if let selectedColor = appearance.state.selectedColor {
-            self.selectedColor = selectedColor
-            self.focussedButton?.setTitleColor(selectedColor, for: .normal)
-            self.focussedButton?.tintColor = selectedColor
-        }
+        let isScrollEnabled = appearance.interaction.isScrollEnabled
+        self.isScrollEnabled = isScrollEnabled ?? defaultAppearance.interaction.isScrollEnabled!
         
-        if let edgeInset = appearance.layout.edgeInset {
-            self.edgeInset = edgeInset
-            self.updateForCurrentPosition()
-        }
-        
-        if let isScrollEnabled = appearance.interaction.isScrollEnabled {
-            self.scrollView.isScrollEnabled = isScrollEnabled
-            UIView.animate(withDuration: 0.3, animations: { // reset scroll position
-                self.transitionStore?.indicatorTransition(forBar: self)?.updateForCurrentPosition()
-            })
-        }
-        
-        if let indicatorIsProgressive = appearance.indicator.isProgressive {
-            self.indicatorLeftMargin?.constant = indicatorIsProgressive ? 0.0 : self.edgeInset
-            UIView.animate(withDuration: 0.3, animations: {
-                self.updateForCurrentPosition()
-            })
-        }
+        let indicatorIsProgressive = appearance.indicator.isProgressive ?? defaultAppearance.indicator.isProgressive!
+        self.indicatorLeftMargin?.constant = indicatorIsProgressive ? 0.0 : self.edgeInset
     }
-    
-    
     
     //
     // MARK: Layout

--- a/Sources/Tabman/TabmanBar/Styles/TabmanScrollingButtonBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/TabmanScrollingButtonBar.swift
@@ -21,7 +21,6 @@ public class TabmanScrollingButtonBar: TabmanButtonBar {
     
     private struct Defaults {
         
-        static let edgeInset: CGFloat = 16.0
         static let minimumItemWidth: CGFloat = 44.0
     }
     
@@ -49,8 +48,8 @@ public class TabmanScrollingButtonBar: TabmanButtonBar {
         }
     }
     
-    /// The inset at the edge of the bar items. (Default = 16.0)
-    public var edgeInset: CGFloat = Appearance.defaultAppearance.layout.edgeInset ?? Defaults.edgeInset {
+    /// The inset at the edge of the bar items.
+    public var edgeInset: CGFloat = Appearance.defaultAppearance.layout.edgeInset! {
         didSet {
             self.updateConstraints(self.edgeMarginConstraints,
                                    withValue: edgeInset)

--- a/Sources/Tabman/TabmanBar/Styles/TabmanScrollingButtonBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/TabmanScrollingButtonBar.swift
@@ -128,8 +128,10 @@ public class TabmanScrollingButtonBar: TabmanButtonBar {
         self.indicatorWidth = indicator.autoSetDimension(.width, toSize: 0.0)
     }
     
-    override public func update(forAppearance appearance: TabmanBar.Appearance) {
-        super.update(forAppearance: appearance)
+    override public func update(forAppearance appearance: Appearance,
+                                defaultAppearance: Appearance) {
+        super.update(forAppearance: appearance,
+                     defaultAppearance: defaultAppearance)
         
         if let color = appearance.state.color {
             self.color = color

--- a/Sources/Tabman/TabmanBar/TabmanBar.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar.swift
@@ -101,7 +101,15 @@ open class TabmanBar: UIView, TabmanBarLifecycle {
     }
     internal var indicatorLeftMargin: NSLayoutConstraint?
     internal var indicatorWidth: NSLayoutConstraint?
-    internal var indicatorIsProgressive: Bool = TabmanBar.Appearance.defaultAppearance.indicator.isProgressive ?? false
+    internal var indicatorIsProgressive: Bool = TabmanBar.Appearance.defaultAppearance.indicator.isProgressive ?? false {
+        didSet {
+            guard indicatorIsProgressive != oldValue else { return }
+            
+            UIView.animate(withDuration: 0.3, animations: {
+                self.updateForCurrentPosition()
+            })
+        }
+    }
     internal var indicatorBounces: Bool = TabmanBar.Appearance.defaultAppearance.indicator.bounces ?? false
     internal var indicatorMaskView: UIView = {
         let maskView = UIView()
@@ -274,20 +282,14 @@ open class TabmanBar: UIView, TabmanBarLifecycle {
     open func update(forAppearance appearance: Appearance,
                      defaultAppearance: Appearance) {
         
-        if let indicatorIsProgressive = appearance.indicator.isProgressive {
-            self.indicatorIsProgressive = indicatorIsProgressive
-            UIView.animate(withDuration: 0.3, animations: {
-                self.updateForCurrentPosition()
-            })
-        }
+        let indicatorIsProgressive = appearance.indicator.isProgressive
+        self.indicatorIsProgressive = indicatorIsProgressive ?? defaultAppearance.indicator.isProgressive!
 
-        if let indicatorBounces = appearance.indicator.bounces {
-            self.indicatorBounces = indicatorBounces
-        }
+        let indicatorBounces = appearance.indicator.bounces
+        self.indicatorBounces = indicatorBounces ?? defaultAppearance.indicator.bounces!
         
-        if let indicatorColor = appearance.indicator.color {
-            self.indicator?.tintColor = indicatorColor
-        }
+        let indicatorColor = appearance.indicator.color
+        self.indicator?.tintColor = indicatorColor ?? defaultAppearance.indicator.color!
         
         self.updateEdgeFade(visible: appearance.style.showEdgeFade ?? false)
     }

--- a/Sources/Tabman/TabmanBar/TabmanBar.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar.swift
@@ -10,6 +10,7 @@ import UIKit
 import PureLayout
 import Pageboy
 
+/// A bar that displays the current page status of a TabmanViewController.
 open class TabmanBar: UIView, TabmanBarLifecycle {
     
     //
@@ -29,9 +30,13 @@ open class TabmanBar: UIView, TabmanBarLifecycle {
         case custom(type: TabmanBar.Type)
     }
     
+    /// The height for the bar.
+    ///
+    /// - auto: Autosize the bar according to its contents.
+    /// - explicit: Explicit value for the bar height.
     public enum Height {
         case auto
-        case explicit(height: CGFloat)
+        case explicit(value: CGFloat)
     }
     
     //

--- a/Sources/Tabman/TabmanBar/TabmanBar.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar.swift
@@ -267,10 +267,12 @@ open class TabmanBar: UIView, TabmanBarLifecycle {
         
         self.height = appearance.layout.height ?? .auto
         
-        self.update(forAppearance: appearance)
+        self.update(forAppearance: appearance,
+                    defaultAppearance: Appearance.defaultAppearance)
     }
     
-    open func update(forAppearance appearance: Appearance) {
+    open func update(forAppearance appearance: Appearance,
+                     defaultAppearance: Appearance) {
         
         if let indicatorIsProgressive = appearance.indicator.isProgressive {
             self.indicatorIsProgressive = indicatorIsProgressive

--- a/Sources/Tabman/TabmanBar/TabmanBar.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar.swift
@@ -66,6 +66,7 @@ open class TabmanBar: UIView, TabmanBarLifecycle {
         }
     }
     
+    /// The height for the bar. Default: .auto
     public var height: Height = .auto {
         didSet {
             self.invalidateIntrinsicContentSize()
@@ -263,6 +264,8 @@ open class TabmanBar: UIView, TabmanBarLifecycle {
         if let backgroundStyle = appearance.style.background {
             self.backgroundView.backgroundStyle = backgroundStyle
         }
+        
+        self.height = appearance.layout.height ?? .auto
         
         self.update(forAppearance: appearance)
     }

--- a/Sources/Tabman/TabmanBar/TabmanBar.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar.swift
@@ -29,6 +29,11 @@ open class TabmanBar: UIView, TabmanBarLifecycle {
         case custom(type: TabmanBar.Type)
     }
     
+    public enum Height {
+        case auto
+        case explicit(height: CGFloat)
+    }
+    
     //
     // MARK: Properties
     //
@@ -58,6 +63,26 @@ open class TabmanBar: UIView, TabmanBarLifecycle {
     public var appearance: Appearance = .defaultAppearance {
         didSet {
             self.updateCore(forAppearance: appearance)
+        }
+    }
+    
+    public var height: Height = .auto {
+        didSet {
+            self.invalidateIntrinsicContentSize()
+            self.superview?.setNeedsLayout()
+            self.superview?.layoutIfNeeded()
+        }
+    }
+    open override var intrinsicContentSize: CGSize {
+        var autoSize = super.intrinsicContentSize
+        switch self.height {
+    
+        case .explicit(let height):
+            autoSize.height = height
+            return autoSize
+            
+        default:
+            return autoSize
         }
     }
     

--- a/Sources/Tabman/TabmanBar/TabmanBarAppearance.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBarAppearance.swift
@@ -102,6 +102,10 @@ public extension TabmanBar {
             
             // indicator
             self.indicator.bounces = true
+            self.indicator.isProgressive = false
+            self.indicator.useRoundedCorners = false
+            self.indicator.lineWeight = .normal
+            self.indicator.color = UIView.defaultTintColor
             
             // state
             self.state.selectedColor = .black
@@ -115,6 +119,8 @@ public extension TabmanBar {
             self.layout.interItemSpacing = 20.0
             self.layout.edgeInset = 16.0
             
+            // interaction
+            self.interaction.isScrollEnabled = false
         }
     }
 }

--- a/Sources/Tabman/TabmanBar/TabmanBarAppearance.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBarAppearance.swift
@@ -52,6 +52,8 @@ public extension TabmanBar {
             public var interItemSpacing: CGFloat?
             /// The spacing at the edge of the items in the bar.
             public var edgeInset: CGFloat?
+            /// The height for the bar.
+            public var height: TabmanBar.Height?
         }
         
         /// Bar style configuration.
@@ -97,8 +99,11 @@ public extension TabmanBar {
         }
         
         private func setDefaultValues() {
-            
+            // indicator
             self.indicator.bounces = true
+            
+            // layout
+            self.layout.height = .auto
         }
     }
 }

--- a/Sources/Tabman/TabmanBar/TabmanBarAppearance.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBarAppearance.swift
@@ -99,11 +99,22 @@ public extension TabmanBar {
         }
         
         private func setDefaultValues() {
+            
             // indicator
             self.indicator.bounces = true
             
+            // state
+            self.state.selectedColor = .black
+            self.state.color = UIColor.black.withAlphaComponent(0.5)
+            
+            // text
+            self.text.font = UIFont.systemFont(ofSize: 16.0)
+            
             // layout
             self.layout.height = .auto
+            self.layout.interItemSpacing = 20.0
+            self.layout.edgeInset = 16.0
+            
         }
     }
 }

--- a/Sources/Tabman/TabmanBar/TabmanBarAppearance.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBarAppearance.swift
@@ -125,5 +125,6 @@ public protocol TabmanAppearanceUpdateable {
     /// Update the appearance of the tab bar for a new configuration.
     ///
     /// - Parameter appearance: The new configuration.
-    func update(forAppearance appearance: TabmanBar.Appearance)
+    /// - Parameter default: The default appearance configuration.
+    func update(forAppearance appearance: TabmanBar.Appearance, defaultAppearance: TabmanBar.Appearance)
 }

--- a/Sources/Tabman/TabmanBar/Utilities/ViewUtils.swift
+++ b/Sources/Tabman/TabmanBar/Utilities/ViewUtils.swift
@@ -1,0 +1,18 @@
+//
+//  ViewUtils.swift
+//  Tabman
+//
+//  Created by Merrick Sapsford on 16/03/2017.
+//  Copyright © 2017 Merrick Sapsford. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+    
+    /// The default tintColor of UIView
+    class var defaultTintColor: UIColor {
+        let view = UIView()
+        return view.tintColor
+    }
+}

--- a/Sources/TabmanTests/Components/TabmanTestBar.swift
+++ b/Sources/TabmanTests/Components/TabmanTestBar.swift
@@ -71,8 +71,10 @@ class TabmanTestBar: TabmanBar {
         self.latestDirection = direction
     }
     
-    override func update(forAppearance appearance: TabmanBar.Appearance) {
-        super.update(forAppearance: appearance)
+    override func update(forAppearance appearance: Appearance,
+                         defaultAppearance: Appearance) {
+        super.update(forAppearance: appearance,
+                     defaultAppearance: defaultAppearance)
         
         self.latestAppearanceConfig = appearance
     }


### PR DESCRIPTION
- Add `.height` (`TabmanBar.Height`) property to `TabmanBar` to allow for custom size specification.
- Remove class specific default appearance configuration. 
- Centralise default appearance configuration to `TabmanBar.Appearance.defaultAppearance`.
- Update appearance handling to better handle setting of properties.