### PR TITLE
Bump Pageboy from 5.0.1 to 5.0.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,14 +1,15 @@
 {
+  "originHash" : "1a2774f2b9a19abf85b7a496f11f0a878f46aa87c0360293fe1b0648a5c233b1",
   "pins" : [
     {
       "identity" : "pageboy",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/uias/Pageboy",
       "state" : {
-        "revision" : "be0c1f6f1964cfb07f9d819b0863f2c3f255f612",
-        "version" : "4.2.0"
+        "revision" : "293e7860ac0eafabd7301cad5fe69bdabde56102",
+        "version" : "5.0.2"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["Tabman"])
     ],
     dependencies: [
-        .package(url: "https://github.com/uias/Pageboy", from: "5.0.1")
+        .package(url: "https://github.com/uias/Pageboy", from: "5.0.2")
     ],
     targets: [
         .target(

--- a/Sources/Tabman.xcodeproj/project.pbxproj
+++ b/Sources/Tabman.xcodeproj/project.pbxproj
@@ -1003,7 +1003,7 @@
 			repositoryURL = "https://github.com/uias/Pageboy";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.0.1;
+				minimumVersion = 5.0.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Tabman.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tabman.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "a758ccf717fdfdb86f09136097e776d790bde8518689cbfe41619ea2215ecb20",
+  "originHash" : "1a2774f2b9a19abf85b7a496f11f0a878f46aa87c0360293fe1b0648a5c233b1",
   "pins" : [
     {
       "identity" : "pageboy",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/uias/Pageboy",
       "state" : {
-        "revision" : "d522ccd03a87db72bf9b2df52808522134139001",
-        "version" : "5.0.1"
+        "revision" : "293e7860ac0eafabd7301cad5fe69bdabde56102",
+        "version" : "5.0.2"
       }
     }
   ],


### PR DESCRIPTION
@msaps 

## Summary

- Updates the Pageboy dependency from `5.0.1` to `5.0.2`
- Updates `Package.swift`, `project.pbxproj`, and both `Package.resolved` files

## Changes

| File | Change |
|------|--------|
| `Package.swift` | `from: "5.0.1"` → `from: "5.0.2"` |
| `Sources/Tabman.xcodeproj/project.pbxproj` | `minimumVersion = 5.0.1` → `minimumVersion = 5.0.2` |
| `Package.resolved` | Pinned to Pageboy 5.0.2 (`293e7860`) |
| `Tabman.xcworkspace/.../Package.resolved` | Pinned to Pageboy 5.0.2 (`293e7860`) |